### PR TITLE
Update LinkedIn URL to make it absolute

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
      			<ul>
      				<li><a href="https://github.com/suresh021" target="_blank" class="fa fa-github" title="GitHub"></a></li>
      				<li><a href="https://stackoverflow.com/users/5131437/suresh-pokharel" target="_blank" class="fa fa-stack-overflow" title="Stack Overflow"></a></li>
-     				<li><a href="www.linkedin.com/in/suresh-pokharel" target="_blank" class="fa fa-linkedin" title="LinkedIn"></a></li>
+     				<li><a href="https://www.linkedin.com/in/suresh-pokharel/" target="_blank" class="fa fa-linkedin" title="LinkedIn"></a></li>
      				<li><a href="https://www.facebook.com/pokharelsuresh1" target="_blank" class="fa fa-facebook" title="Facebook"></a></li>
      				<li><a href="https://twitter.com/pokharelsuresh1" target="_blank" class="fa fa-twitter" title="Twitter"></a></li>
      				


### PR DESCRIPTION
The LinkedIn URL was relative previously which lead to a 404 page.